### PR TITLE
Anime consolidate jsons into parquet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Gecko
 Generic Universal Recommender System
+
+# Loading to S3 
+Since we are only mocking the connection to S3, we are not using AWS cloud. Instead we use a docker to mock the behaviour. We use adobe implemention of the mock. More information can be found here: https://github.com/adobe/S3Mock
+To run the docker container, run in the root folder of the project 
+
+```sh
+docker compose up -d
+```
+This will initialize the docker container for S3.
+
+To interact with S3 you need to have the AWS CLI. This can be downloaded and installed following the steps in https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html 
+
+The details on the usage of this tool are explained in the README inside `/anime/` and `/boardgames/`

--- a/anime/README.md
+++ b/anime/README.md
@@ -1,0 +1,24 @@
+# To run the files
+Run the scrape file to your hearts content. The longest it runs the better. It will generate around 5GB of data per day.
+
+``` sh
+python src/scrape.py
+```
+
+Then transform your data using parquet with
+
+``` sh
+python src/consolidate.py
+```
+
+# To copy the files into the S3 docker container
+
+You can copy the files to S3 docker mock using the script provided
+
+``` sh
+sh stage_parquets.sh
+```
+You can check for the files you uploaded with the `ls` command in AWS.
+``` sh
+aws s3 ls gecko/anime/ --endpoint-url=http://localhost:9090
+```

--- a/anime/src/consolidate.py
+++ b/anime/src/consolidate.py
@@ -22,45 +22,62 @@ def make_directory():
     if not os.path.exists(folder_route):
         os.makedirs(folder_route)
 
-def read_jsons_to_dataframe(folder_path):
+def read_jsons_to_dataframe(file_names, folder_path):
     data = []
-    file_names = []
 
-    for filename in os.listdir(folder_path):
+    for filename in file_names:
         if filename.endswith('.json'):
             with open(os.path.join(folder_path, filename), 'r') as file:
                 json_content = json.load(file)
                 data.append(json_content)
-                file_names.append(filename)
 
     df = pd.DataFrame({'id': file_names, 'json': data})
+    df.json = df.json.astype(str)
     return df
+
+def generate_partitioned_parquets_for_folder_path(folder_name):
+    folder_path = f'./data/{folder_name}'
+    files = os.listdir(folder_path)
+    pagination_size = 500
+    elements = 0
+    cnt = 0
+    while elements < len(files):
+        cnt += 1
+        elements += pagination_size
+        dataframe = read_jsons_to_dataframe(
+            files[pagination_size*(cnt-1):min(pagination_size*cnt, len(files))],
+            folder_path
+        )
+        output_file = f'./parquets/{folder_name}_{cnt}.parquet'
+        write_dataframe_to_parquet(dataframe, output_file)
+        print(f"Parquet file '{output_file}' has been generated successfully.")
+
 
 def write_dataframe_to_parquet(dataframe, output_file):
     table = pa.Table.from_pandas(dataframe)
     pq.write_table(table, output_file)
 
 def generate_parquet_for_folder_path(folder_path, output_file):
-    change_directory_root()
-
-    dataframe = read_jsons_to_dataframe(folder_path)
+    files = os.listdir(folder_path)
+    dataframe = read_jsons_to_dataframe(files, folder_path)
     write_dataframe_to_parquet(dataframe, output_file)
     print(f"Parquet file '{output_file}' has been generated successfully.")
 
 
 def main ():
+    change_directory_root()
     make_directory()
     folder_names = [
         'anime_info',
         'anime_reviews',
-        'user_info'
-        # TODO uncomment this line, this is very heavy so i haven't runned it
-        # 'user_anime_list',
+        'user_info',
     ]
+    generate_partitioned_parquets_for_folder_path('user_anime_list')
+
     for folder_name in folder_names:
         generate_parquet_for_folder_path(
             f'./data/{folder_name}',
-            f'./parquets/{folder_name}'
+            f'./parquets/{folder_name}.parquet'
         )
 
 if __name__ == "__main__":

--- a/anime/src/consolidate.py
+++ b/anime/src/consolidate.py
@@ -38,7 +38,7 @@ def read_jsons_to_dataframe(file_names, folder_path):
 def generate_partitioned_parquets_for_folder_path(folder_name):
     folder_path = f'./data/{folder_name}'
     files = os.listdir(folder_path)
-    pagination_size = 500
+    pagination_size = 1
     elements = 0
     cnt = 0
     while elements < len(files):
@@ -70,7 +70,7 @@ def main ():
     folder_names = [
         'anime_info',
         'anime_reviews',
-        'user_info',
+        'user_info'
     ]
     generate_partitioned_parquets_for_folder_path('user_anime_list')
 

--- a/anime/src/consolidate.py
+++ b/anime/src/consolidate.py
@@ -38,14 +38,17 @@ def read_jsons_to_dataframe(file_names, folder_path):
 def generate_partitioned_parquets_for_folder_path(folder_name):
     folder_path = f'./data/{folder_name}'
     files = os.listdir(folder_path)
-    files_df = pd.DataFrame({'file_name':files})
-    files_df['first_letter'] = files_df.file_name.apply(lambda x: x[0].lower() if x[0].isalpha() else '*')
-    for prefix, group in files_df.groupby('first_letter'):
+    pagination_size = 500
+    elements = 0
+    cnt = 0
+    while elements < len(files):
+        cnt += 1
+        elements += pagination_size
         dataframe = read_jsons_to_dataframe(
-            group.file_name.values,
+            files[pagination_size*(cnt-1):min(pagination_size*cnt, len(files))],
             folder_path
         )
-        output_file = f'./parquets/{folder_name}_{prefix}.parquet'
+        output_file = f'./parquets/{folder_name}_{cnt}.parquet'
         write_dataframe_to_parquet(dataframe, output_file)
         print(f"Parquet file '{output_file}' has been generated successfully.")
 
@@ -64,15 +67,12 @@ def generate_parquet_for_folder_path(folder_path, output_file):
 def main ():
     change_directory_root()
     make_directory()
-    # Generate Partitioned data according to first letter
-    generate_partitioned_parquets_for_folder_path('user_anime_list')
-
-    # Saves in parquet normally
     folder_names = [
         'anime_info',
         'anime_reviews',
         'user_info',
     ]
+    generate_partitioned_parquets_for_folder_path('user_anime_list')
 
     for folder_name in folder_names:
         generate_parquet_for_folder_path(

--- a/anime/src/consolidate.py
+++ b/anime/src/consolidate.py
@@ -1,0 +1,67 @@
+import os
+import json
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+def directory_up(path: str, n: int):
+    for _ in range(n):
+        path = directory_up(path.rpartition("/")[0], 0)
+    return path
+
+def change_directory_root():
+    root_path = os.path.dirname(os.path.realpath(__file__))
+    # Change working directory to root of the project.
+    os.chdir(directory_up(root_path, 1))
+
+def make_directory():
+    '''
+    Creates neccesary directories if they don't exist.
+    '''
+    folder_route = './parquets/'
+    if not os.path.exists(folder_route):
+        os.makedirs(folder_route)
+
+def read_jsons_to_dataframe(folder_path):
+    data = []
+    file_names = []
+
+    for filename in os.listdir(folder_path):
+        if filename.endswith('.json'):
+            with open(os.path.join(folder_path, filename), 'r') as file:
+                json_content = json.load(file)
+                data.append(json_content)
+                file_names.append(filename)
+
+    df = pd.DataFrame({'id': file_names, 'json': data})
+    return df
+
+def write_dataframe_to_parquet(dataframe, output_file):
+    table = pa.Table.from_pandas(dataframe)
+    pq.write_table(table, output_file)
+
+def generate_parquet_for_folder_path(folder_path, output_file):
+    change_directory_root()
+
+    dataframe = read_jsons_to_dataframe(folder_path)
+    write_dataframe_to_parquet(dataframe, output_file)
+    print(f"Parquet file '{output_file}' has been generated successfully.")
+
+
+def main ():
+    make_directory()
+    folder_names = [
+        'anime_info',
+        'anime_reviews',
+        'user_info'
+        # TODO uncomment this line, this is very heavy so i haven't runned it
+        # 'user_anime_list',
+    ]
+    for folder_name in folder_names:
+        generate_parquet_for_folder_path(
+            f'./data/{folder_name}',
+            f'./parquets/{folder_name}'
+        )
+
+if __name__ == "__main__":
+    main()

--- a/anime/stage_parquets.sh
+++ b/anime/stage_parquets.sh
@@ -1,0 +1,2 @@
+aws s3api create-bucket --bucket gecko --endpoint-url=http://localhost:9090
+aws s3 cp parquets/ s3://gecko/anime --endpoint-url=http://localhost:9090 --recursive


### PR DESCRIPTION
Read json files and makes parquet.

It should be straight forward.... it should....


The problem is users anime list can be quite big. Thus i had to split it into multiple parquets with no special partition key whatsoever, it just saves every 500 users. It saves the data in parquets and I am happy enough with that. 


Reading the data is straightforward
![image](https://github.com/DionisiusMayr/Gecko/assets/37823629/0c95c5b6-f135-4170-a342-67b59794c964)
